### PR TITLE
Changing reference to constant in defenition of "istream" operator

### DIFF
--- a/dist/matrix.cpp
+++ b/dist/matrix.cpp
@@ -528,7 +528,7 @@ ostream& operator<<(ostream& os, const Matrix& m)
     return os;
 }
 
-istream& operator>>(istream& is, Matrix& m)
+istream& operator>>(istream& is, const Matrix& m)
 {
     for (int i = 0; i < m.rows_; ++i) {
         for (int j = 0; j < m.cols_; ++j) {

--- a/dist/matrix.h
+++ b/dist/matrix.h
@@ -25,7 +25,7 @@ class Matrix {
         Matrix  operator^(int);
         
         friend std::ostream& operator<<(std::ostream&, const Matrix&);
-        friend std::istream& operator>>(std::istream&, Matrix&);
+        friend std::istream& operator>>(std::istream&, const Matrix&);
 
         void swapRows(int, int);
         Matrix transpose();


### PR DESCRIPTION
Changed in "matrix.h" and "matrix.cpp" 
`istream& operator>>(istream& is, Matrix& m)`
to
`istream& operator>>(istream& is, const Matrix& m)`
